### PR TITLE
refactor: export errors, code as enum

### DIFF
--- a/js/src/common.ts
+++ b/js/src/common.ts
@@ -21,40 +21,59 @@ export const P1_VALUES = {
   SHOW_ADDRESS_IN_DEVICE: 0x01,
 };
 
-export const ERROR_CODE = {
-  NoError: 0x9000,
-};
-
 export const PKLEN = 33;
 
-const ERROR_DESCRIPTION = {
-  1: 'U2F: Unknown',
-  2: 'U2F: Bad request',
-  3: 'U2F: Configuration unsupported',
-  4: 'U2F: Device Ineligible',
-  5: 'U2F: Timeout',
-  14: 'Timeout',
-  0x9000: 'No errors',
-  0x9001: 'Device is busy',
-  0x6802: 'Error deriving keys',
-  0x6400: 'Execution Error',
-  0x6700: 'Wrong Length',
-  0x6982: 'Empty Buffer',
-  0x6983: 'Output buffer too small',
-  0x6984: 'Data is invalid',
-  0x6985: 'Conditions not satisfied',
-  0x6986: 'Transaction rejected',
-  0x6a80: 'Bad key handle',
-  0x6b00: 'Invalid P1/P2',
-  0x6d00: 'Instruction not supported',
-  0x6e00: 'App does not seem to be open',
-  0x6f00: 'Unknown error',
-  0x6f01: 'Sign/verify error',
+export enum LedgerError {
+  U2FUnknown = 1,
+  U2FBadRequest = 2,
+  U2FConfigurationUnsupported = 3,
+  U2FDeviceIneligible = 4,
+  U2FTimeout = 5,
+  Timeout = 14,
+  NoErrors = 0x9000,
+  DeviceIsBusy = 0x9001,
+  ErrorDerivingKeys = 0x6802,
+  ExecutionError = 0x6400,
+  WrongLength = 0x6700,
+  EmptyBuffer = 0x6982,
+  OutputBufferTooSmall = 0x6983,
+  DataIsInvalid = 0x6984,
+  ConditionsNotSatisfied = 0x6985,
+  TransactionRejected = 0x6986,
+  BadKeyHandle = 0x6a80,
+  InvalidP1P2 = 0x6b00,
+  InstructionNotSupported = 0x6d00,
+  AppDoesNotSeemToBeOpen = 0x6e00,
+  UnknownError = 0x6f00,
+  SignVerifyError = 0x6f01,
+}
+
+export const ERROR_DESCRIPTION = {
+  [LedgerError.U2FUnknown]: 'U2F: Unknown',
+  [LedgerError.U2FBadRequest]: 'U2F: Bad request',
+  [LedgerError.U2FConfigurationUnsupported]: 'U2F: Configuration unsupported',
+  [LedgerError.U2FDeviceIneligible]: 'U2F: Device Ineligible',
+  [LedgerError.U2FTimeout]: 'U2F: Timeout',
+  [LedgerError.Timeout]: 'Timeout',
+  [LedgerError.NoErrors]: 'No errors',
+  [LedgerError.DeviceIsBusy]: 'Device is busy',
+  [LedgerError.ErrorDerivingKeys]: 'Error deriving keys',
+  [LedgerError.ExecutionError]: 'Execution Error',
+  [LedgerError.WrongLength]: 'Wrong Length',
+  [LedgerError.EmptyBuffer]: 'Empty Buffer',
+  [LedgerError.OutputBufferTooSmall]: 'Output buffer too small',
+  [LedgerError.DataIsInvalid]: 'Data is invalid',
+  [LedgerError.ConditionsNotSatisfied]: 'Conditions not satisfied',
+  [LedgerError.TransactionRejected]: 'Transaction rejected',
+  [LedgerError.BadKeyHandle]: 'Bad key handle',
+  [LedgerError.InvalidP1P2]: 'Invalid P1/P2',
+  [LedgerError.InstructionNotSupported]: 'Instruction not supported',
+  [LedgerError.AppDoesNotSeemToBeOpen]: 'App does not seem to be open',
+  [LedgerError.UnknownError]: 'Unknown error',
+  [LedgerError.SignVerifyError]: 'Sign/verify error',
 };
 
-export type ErrorCode = keyof typeof ERROR_DESCRIPTION;
-
-export function errorCodeToString(statusCode: ErrorCode) {
+export function errorCodeToString(statusCode: LedgerError) {
   if (statusCode in ERROR_DESCRIPTION) return ERROR_DESCRIPTION[statusCode];
   return `Unknown Status Code: ${statusCode}`;
 }
@@ -96,7 +115,7 @@ export function processErrorResponse(response?: any) {
 export async function getVersion(transport: Transport) {
   return transport.send(CLA, INS.GET_VERSION, 0, 0).then(response => {
     const errorCodeData = response.slice(-2);
-    const returnCode = (errorCodeData[0] * 256 + errorCodeData[1]) as ErrorCode;
+    const returnCode = (errorCodeData[0] * 256 + errorCodeData[1]) as LedgerError;
 
     let targetId = 0;
     if (response.length >= 9) {

--- a/js/src/helperV1.ts
+++ b/js/src/helperV1.ts
@@ -1,4 +1,4 @@
-import { CLA, errorCodeToString, INS, PAYLOAD_TYPE, processErrorResponse, ErrorCode } from './common';
+import { CLA, errorCodeToString, INS, PAYLOAD_TYPE, processErrorResponse, LedgerError } from './common';
 import BlockstackApp from '.';
 import { ResponseSign } from './types';
 
@@ -61,28 +61,32 @@ export async function signSendChunkv1(
     payloadType = PAYLOAD_TYPE.LAST;
   }
   return app.transport
-    .send(CLA, INS.SIGN_SECP256K1, payloadType, 0, chunk, [0x9000, 0x6984, 0x6a80])
+    .send(CLA, INS.SIGN_SECP256K1, payloadType, 0, chunk, [
+      LedgerError.NoErrors,
+      LedgerError.DataIsInvalid,
+      LedgerError.BadKeyHandle,
+    ])
     .then(response => {
       const errorCodeData = response.slice(-2);
       const returnCode = errorCodeData[0] * 256 + errorCodeData[1];
-      let errorMessage = errorCodeToString(returnCode as ErrorCode);
+      let errorMessage = errorCodeToString(returnCode as LedgerError);
 
-      if (returnCode === 0x6a80 || returnCode === 0x6984) {
+      if (returnCode === LedgerError.BadKeyHandle || returnCode === LedgerError.DataIsInvalid) {
         errorMessage = `${errorMessage} : ${response
           .slice(0, response.length - 2)
           .toString('ascii')}`;
       }
 
       if (response.length > 2) {
-          const  signatureCompact = response.slice(0, 65);
-          const  signatureDER = response.slice(65, response.length - 2);
+        const signatureCompact = response.slice(0, 65);
+        const signatureDER = response.slice(65, response.length - 2);
 
-          return {
-              signatureCompact,
-              signatureDER,
-              returnCode: returnCode,
-              errorMessage: errorMessage,
-          };
+        return {
+          signatureCompact,
+          signatureDER,
+          returnCode: returnCode,
+          errorMessage: errorMessage,
+        };
       }
 
       return {

--- a/js/vue_example/components/LedgerExample.vue
+++ b/js/vue_example/components/LedgerExample.vue
@@ -36,8 +36,8 @@
 <script>
 import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
 import BlockstackApp from "../../src";
-import { ERROR_CODE } from "../../src/common";
-const EXAMPLE_PATH = "m/44'/5757'/0/0/0";
+import { LedgerError } from "../../src/common";
+const EXAMPLE_PATH = "m/44'/5757'/0'/0/0";
 
 export default {
   name: "Ledger",
@@ -81,7 +81,7 @@ export default {
         const response = await app.getVersion();
         this.log(`${JSON.stringify(response)}`);
 
-        if (response.returnCode !== ERROR_CODE.NoError) {
+        if (response.returnCode !== LedgerError.NoErrors) {
           this.log(`Error`);
           // this.log(`Error [${response.returnCode}] ${response.errorMessage}`);
           return;
@@ -131,7 +131,7 @@ export default {
         response = await app.getAddressAndPubKey(EXAMPLE_PATH);
         this.log(response);
 
-        if (response.returnCode !== ERROR_CODE.NoError) {
+        if (response.returnCode !== LedgerError.NoErrors) {
           this.log(`Error [${response.returnCode}] ${response.errorMessage}`);
           return;
         }
@@ -157,7 +157,7 @@ export default {
         // now it is possible to access all commands in the app
         this.log("Please click in the device");
         response = await app.showAddressAndPubKey(EXAMPLE_PATH);
-        if (response.returnCode !== ERROR_CODE.NoError) {
+        if (response.returnCode !== LedgerError.NoErrors) {
           this.log(`Error [${response.returnCode}] ${response.errorMessage}`);
           return;
         }


### PR DESCRIPTION
This PR refactors errors to be declared as an enum type. Makes for much friendlier error handling than copying the error codes.