### PR TITLE
fix: copy undefined in web environment

### DIFF
--- a/js/src/helperV1.ts
+++ b/js/src/helperV1.ts
@@ -80,9 +80,9 @@ export async function signSendChunkv1(
       if (response.length > 2) {
           const  postSignHash = response.slice(0, 32);
           const  signatureCompact = response.slice(32, 97);
-          var    signatureVRS = Buffer.alloc(65);
+          const    signatureVRS = Buffer.alloc(65);
           signatureVRS[0] = signatureCompact[signatureCompact.length - 1];
-          signatureCompact.copy(signatureVRS, 1, 0, 64);
+          Buffer.from(signatureCompact).copy(signatureVRS, 1, 0, 64);
           const  signatureDER = response.slice(97, response.length - 2);
 
           return {


### PR DESCRIPTION
Using in a browser environment, an error was being thrown as `.copy` doesn't exist on a `Uint8Array`. Casting to `Buffer` solves this.